### PR TITLE
feat(infrastructure)!: add nginx reverse proxy and health monitoring

### DIFF
--- a/backend/src/UserService/Program.cs
+++ b/backend/src/UserService/Program.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
+using Serilog;
 using Shared.Extensions;
 using Shared.Helpers;
 using UserService.Data;
@@ -10,17 +11,9 @@ using UserService.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddCors(options =>
-{
-    options.AddDefaultPolicy(policy =>
-    {
-        policy
-            .WithOrigins("http://localhost:5004")
-            .AllowAnyHeader()
-            .AllowAnyMethod();
-    });
-});
-
+// ----------------------
+// Configuration & Services
+// ----------------------
 builder.Configuration.AddUserSecrets<Program>();
 
 builder.Services.AddSharedFactories(builder.Configuration);
@@ -38,14 +31,24 @@ builder.Services.AddIdentity<ApplicationUser, IdentityRole>()
     .AddEntityFrameworkStores<UserDbContext>()
     .AddDefaultTokenProviders();
 
+// ----------------------
+// Controllers, Swagger & Health Checks
+// ----------------------
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
+// Optional: built-in health checks
+builder.Services.AddHealthChecks();
+
 var app = builder.Build();
 
+// Seed Roles
 await DataSeeder.SeedRoles(app.Services);
 
+// ----------------------
+// Middleware
+// ----------------------
 if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();
@@ -53,9 +56,38 @@ if (app.Environment.IsDevelopment())
 }
 
 app.UseRouting();
-app.UseCors();
 app.UseAuthorization();
 app.MapControllers();
 
+// ----------------------
+// Health Check Endpoint
+// ----------------------
+app.MapGet("/api/user/health", async (UserDbContext dbContext) =>
+{
+    try
+    {
+        var canConnect = await dbContext.Database.CanConnectAsync();
+        return Results.Ok(new
+        {
+            status = canConnect ? "Healthy" : "Degraded",
+            timestamp = DateTime.UtcNow,
+            database = canConnect ? "Connected" : "Disconnected"
+        });
+    }
+    catch (Exception ex)
+    {
+        Log.Warning(ex, "Health check database connection failed");
+        return Results.Ok(new
+        {
+            status = "Degraded",
+            timestamp = DateTime.UtcNow,
+            database = "Error",
+            error = ex.Message
+        });
+    }
+});
 
+// ----------------------
+// Run App
+// ----------------------
 app.Run();

--- a/frontend/src/BlazorWasm/Program.cs
+++ b/frontend/src/BlazorWasm/Program.cs
@@ -1,25 +1,22 @@
 using Blazored.LocalStorage;
-using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+using Microsoft.AspNetCore.Components.Authorization;
 using BlazorWasm;
 using BlazorWasm.Providers;
 using BlazorWasm.Services;
-using Microsoft.AspNetCore.Components.Authorization;
 using MudBlazor.Services;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.RootComponents.Add<App>("#app");
 
-var userServiceUrl = builder.Configuration["ApiUrls:UserService"] 
-                     ?? throw new InvalidOperationException("UserService URL not configured");
-var authServiceUrl = builder.Configuration["ApiUrls:AuthService"] 
-                     ?? throw new InvalidOperationException("AuthService URL not configured");
+var baseUrl = builder.Configuration["ApiUrls:Microservice"]
+              ?? throw new InvalidOperationException("Microservice URL not configured");
 
-builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(userServiceUrl) });
-builder.Services.AddScoped<IAuthApiClient>(sp => 
-    new AuthApiClient(new HttpClient { BaseAddress = new Uri(authServiceUrl) }));
-builder.Services.AddScoped<IUserApiClient>(sp => 
-    new UserApiClient(new HttpClient { BaseAddress = new Uri(userServiceUrl) }));
+builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(baseUrl) });
+
+// Reuse the same base HttpClient for all API clients
+builder.Services.AddScoped<IAuthApiClient, AuthApiClient>();
+builder.Services.AddScoped<IUserApiClient, UserApiClient>();
 
 builder.Services.AddScoped<ITokenService, TokenService>();
 builder.Services.AddAuthorizationCore();

--- a/frontend/src/BlazorWasm/wwwroot/appsettings.json
+++ b/frontend/src/BlazorWasm/wwwroot/appsettings.json
@@ -1,6 +1,5 @@
 {
   "ApiUrls": {
-    "UserService": "http://localhost:5001",
-    "AuthService": "http://localhost:5002"
+    "Microservice": "https://localhost"
   }
 }

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,5 @@
+FROM nginx:alpine
+
+COPY certs /etc/nginx/certs
+
+COPY nginx.conf /etc/nginx/nginx.conf

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,73 @@
+worker_processes 1;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    sendfile on;
+
+    upstream userservice {
+       server userservice:8080;
+    }
+    
+    upstream authservice {
+       server authservice:8080;
+    }
+    
+    upstream loggerservice {
+       server loggerservice:8080;
+    }
+
+    # Redirect all HTTP requests to HTTPS
+    server {
+        listen 80;
+        server_name localhost;
+        return 301 https://$host$request_uri;
+    }
+
+    server {
+        listen 443 ssl;
+        server_name localhost;
+    
+        ssl_certificate     /etc/nginx/certs/server.crt;
+        ssl_certificate_key /etc/nginx/certs/server.key;
+    
+        ssl_protocols TLSv1.2 TLSv1.3;
+        ssl_ciphers HIGH:!aNULL:!MD5;
+    
+        root /usr/share/nginx/html;
+        index index.html;
+    
+        add_header 'Access-Control-Allow-Origin' '*' always;
+        add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS' always;
+        add_header 'Access-Control-Allow-Headers' 'Authorization, Content-Type, Accept' always;
+    
+        if ($request_method = OPTIONS) {
+            return 204;
+        }
+    
+        location / {
+            try_files $uri $uri/ /index.html;
+        }
+    
+        location /api/user/ {
+            proxy_pass http://userservice/api/user/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+        
+        location /api/auth/ {
+           proxy_pass http://authservice/api/auth/;
+           proxy_set_header Host $host;
+           proxy_set_header X-Real-IP $remote_addr;
+        }
+        
+        location /api/logger/ {
+            proxy_pass http://loggerservice/api/logger/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+    }
+}

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+echo "{"
+echo '  "AuthService": ' $(curl -sk https://localhost/api/auth/health | jq -c) ','
+echo '  "UserService": ' $(curl -sk https://localhost/api/user/health | jq -c) ','
+echo '  "LoggerService": ' $(curl -sk https://localhost/api/logger/health | jq -c)
+echo "}"
+


### PR DESCRIPTION
BREAKING CHANGE: Services now accessible only through nginx gateway

- Configure nginx as API gateway with SSL termination
- Implement health checks for service monitoring
- Add CORS handling at gateway level
- Update service port mappings in docker-compose

Endpoints:
- https://localhost/api/auth/* → authservice:8080
- https://localhost/api/user/* → userservice:8080
- https://localhost/api/logger/* → loggerservice:8080

Health checks:
- GET /api/auth/health
- GET /api/user/health
- GET /api/logger/health