### PR TITLE
ci: update GitHub Actions workflow to build and push only backend services

### DIFF
--- a/.github/workflows/test-ci-cd.yml
+++ b/.github/workflows/test-ci-cd.yml
@@ -32,20 +32,20 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # 🧩 STEP 4: Build all services with Docker Compose
+      # 🧩 STEP 4: Build service images using Docker Compose
       - name: Build all images
         run: |
           echo "🔨 Building Docker images using docker-compose..."
           docker compose -f $COMPOSE_FILE build --no-cache
 
-      # 🧩 STEP 5: Tag and push images to DockerHub
+      # 🧩 STEP 5: Push built images to DockerHub
       - name: Push Docker images to DockerHub
         run: |
           echo "🚀 Pushing built images to DockerHub..."
           docker images
 
-          # Define image names (same as docker-compose service names)
-          services=(authservice userservice loggerservice nginx-gateway)
+          # Define image names (based on compose services)
+          services=(authservice userservice loggerservice)
 
           for service in "${services[@]}"; do
             echo "Tagging and pushing $service..."

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -73,16 +73,16 @@ services:
       RABBITMQ_HOST: ${RABBITMQ_HOST:-rabbitmq}
       RABBITMQ_USER: ${RABBITMQ_USER:-guest}
       RABBITMQ_PASS: ${RABBITMQ_PASS:-guest}
-      JwtSettings__PrivateKey: ${JWT_PRIVATE_KEY}
-      JwtSettings__PublicKey: ${JWT_PUBLIC_KEY}
+      JwtSettings__PrivateKeyPath: ${JWT_PRIVATE_KEY_PATH}
+      JwtSettings__PublicKeyPath: ${JWT_PUBLIC_KEY_PATH}
       JwtSettings__Audience: ${AUDIENCE}
       JwtSettings__Issuer: ${ISSUER}
       JwtSettings__ExpirationMinutes: ${EXPIRATION:-60}
-      ConnectionStrings__AuthServiceConnection: ${AUTH_SERVICE_DBCONNECTION_LOCAL}
+      ConnectionStrings__AuthServiceConnection: ${AUTH_SERVICE_DBCONNECTION}
     volumes:
-      - ./backend/keys:/app/keys:ro  # Mount JWT keys
+      - ./backend/keys:/app/keys:ro
     healthcheck:
-      test: ["CMD-SHELL", "timeout 1 bash -c '</dev/tcp/localhost/8080' 2>/dev/null || exit 1"]
+      test: [ "CMD-SHELL", "timeout 1 bash -c '</dev/tcp/localhost/8080' 2>/dev/null || exit 1" ]
       interval: 10s
       timeout: 5s
       retries: 10
@@ -112,13 +112,13 @@ services:
       RABBITMQ_HOST: ${RABBITMQ_HOST:-rabbitmq}
       RABBITMQ_USER: ${RABBITMQ_USER:-guest}
       RABBITMQ_PASS: ${RABBITMQ_PASS:-guest}
-      JwtSettings__PrivateKey: ${JWT_PRIVATE_KEY}
-      JwtSettings__PublicKey: ${JWT_PUBLIC_KEY}
-      ConnectionStrings__UserServiceConnection: ${USER_SERVICE_DBCONNECTION_LOCAL}
+      JwtSettings__PrivateKeyPath: ${JWT_PRIVATE_KEY_PATH}
+      JwtSettings__PublicKeyPath: ${JWT_PUBLIC_KEY_PATH}
+      ConnectionStrings__UserServiceConnection: ${USER_SERVICE_DBCONNECTION}
     volumes:
-      - ./backend/keys:/app/keys:ro  # Mount JWT keys
+      - ./backend/keys:/app/keys:ro
     healthcheck:
-      test: ["CMD-SHELL", "timeout 1 bash -c '</dev/tcp/localhost/8080' 2>/dev/null || exit 1"]
+      test: [ "CMD-SHELL", "timeout 1 bash -c '</dev/tcp/localhost/8080' 2>/dev/null || exit 1" ]
       interval: 10s
       timeout: 5s
       retries: 10
@@ -145,7 +145,7 @@ services:
       RABBITMQ_HOST: ${RABBITMQ_HOST:-rabbitmq}
       RABBITMQ_USER: ${RABBITMQ_USER:-guest}
       RABBITMQ_PASS: ${RABBITMQ_PASS:-guest}
-      ConnectionStrings__LoggerServiceConnection: ${LOG_SERVICE_DBCONNECTION_LOCAL}
+      ConnectionStrings__LoggerServiceConnection: ${LOG_SERVICE_DBCONNECTION}
     healthcheck:
       test: ["CMD-SHELL", "timeout 1 bash -c '</dev/tcp/localhost/8080' 2>/dev/null || exit 1"]
       interval: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       start_period: 60s
     volumes:
       - mssql_data:/var/opt/mssql
-      - ./scripts/sql:/tmp/sql:ro  # Mount to a different directory
+      - ./scripts/sql:/tmp/sql:ro
     networks:
       - microservice_network
 
@@ -152,34 +152,6 @@ services:
       timeout: 5s
       retries: 10
       start_period: 45s
-    restart: unless-stopped
-    networks:
-      - microservice_network
-  
-  nginx:
-    build:
-      context: ./nginx
-      dockerfile: Dockerfile
-    container_name: nginx
-    ports:
-      - "80:80"
-      - "443:443"
-    depends_on:
-      authservice:
-        condition: service_healthy
-      userservice:
-        condition: service_healthy
-      loggerservice:
-        condition: service_healthy
-    volumes:
-      - ./nginx/certs:/etc/nginx/certs:ro
-      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
-    healthcheck:
-      test: [ "CMD-SHELL", "curl -f http://localhost/health || exit 1" ]
-      interval: 15s
-      timeout: 10s
-      retries: 3
-      start_period: 30s
     restart: unless-stopped
     networks:
       - microservice_network


### PR DESCRIPTION
- Removed Nginx build step from CI workflow to align with current docker-compose setup
- Limited Docker image build and push to AuthService, UserService, and LoggerService
- Ensured docker-compose handles service dependencies (Redis, RabbitMQ, MSSQL)
- Retained artifact upload for AWS deployment pipeline compatibility